### PR TITLE
feat: add public_url parameter to document upload functions

### DIFF
--- a/mindmap/routers/sources.py
+++ b/mindmap/routers/sources.py
@@ -433,6 +433,7 @@ async def add_source(
     file: UploadFile | None = File(None),
     link: str = Form(None),
     name: str = Form(""),
+    public_url: str | None = Form(None),
 ):
     start_time = time()
 
@@ -484,6 +485,9 @@ async def add_source(
             f"sources/{id}/versions/1/{start_time}_state"
         )
         docs["documents"].append(new_document)
+
+        if public_url:
+            new_document["public_url"] = public_url
 
         if file:
             new_document["name"] = urllib.parse.unquote(file.filename or "")
@@ -834,6 +838,7 @@ async def add_version(
     source_id: str,
     file: UploadFile | None = File(None),
     link: str = Form(None),
+    public_url: str | None = Form(None),
 ):
     start_time = time()
 
@@ -924,6 +929,9 @@ async def add_version(
             f"sources/{source_id}/versions/{version}/{start_time}_state"
         )
         docs["documents"].append(new_document)
+
+        if public_url:
+            new_document["public_url"] = public_url
 
         if file:
             new_document["name"] = urllib.parse.unquote(file.filename or "")
@@ -1032,6 +1040,7 @@ async def try_process_again(
     version: int,
     file: UploadFile | None = File(None),
     link: str = Form(None),
+    public_url: str | None = Form(None),
 ):
     start_time = time()
 
@@ -1079,6 +1088,9 @@ async def try_process_again(
         new_document["updated"] = start_time
         new_document["status"] = "IN_PROGRESS"
         new_document["status_description"] = None
+
+        if public_url:
+            new_document["public_url"] = public_url
 
         if file:
             new_document["name"] = urllib.parse.unquote(file.filename or "")


### PR DESCRIPTION
### Applicable issues

- None (N/A)

### Description of changes

This pull request introduces support for a new `public_url` parameter during document uploads. 

Key changes:
- If the `public_url` is provided by the frontend, it is added as a parameter to the uploaded documents metadata.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.