### PR TITLE
feat: include public_url in references metadata

### DIFF
--- a/mindmap/utils/dial_api.py
+++ b/mindmap/utils/dial_api.py
@@ -98,6 +98,7 @@ async def build_references(
                             "doc_type": doc["type"],
                             "doc_content_type": doc["content_type"],
                             "doc_url": doc["url"],
+                            "public_url": doc.get("public_url"),
                             "content": doc["pages"][int(chunk_id) - 1],
                             "content_type": "image/jpeg",
                         }
@@ -133,6 +134,7 @@ async def build_references(
                             "doc_type": doc["type"],
                             "doc_content_type": doc["content_type"],
                             "doc_url": doc["url"],
+                            "public_url": doc.get("public_url"),
                             "content_type": "text/markdown",
                             "source_name": source_name,
                         }


### PR DESCRIPTION
### Applicable issues

- None (N/A)

### Description of changes

Following up on the previous merge (which added the `public_url` to uploaded documents), this pull request extends that implementation to ensure the URL is also stored in the references metadata.

Key changes:
- Added the `public_url` parameter to the references metadata.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.